### PR TITLE
Fix the module import error for TransformerLoss.py

### DIFF
--- a/TrainingInterfaces/Text_to_Spectrogram/TransformerTTS/TransformerTTS.py
+++ b/TrainingInterfaces/Text_to_Spectrogram/TransformerTTS/TransformerTTS.py
@@ -17,7 +17,7 @@ from Layers.TransformerTTSDecoder import Decoder
 from Layers.TransformerTTSDecoderPrenet import DecoderPrenet
 from Layers.TransformerTTSEncoder import Encoder
 from Layers.TransformerTTSEncoderPrenet import EncoderPrenet
-from TrainingInterfaces.Text_to_Spectrogram.TransformerTTS import TransformerLoss
+from TrainingInterfaces.Text_to_Spectrogram.TransformerTTS.TransformerLoss import TransformerLoss
 from Utility.SoftDTW.sdtw_cuda_loss import SoftDTW
 from Utility.utils import initialize
 from Utility.utils import make_non_pad_mask


### PR DESCRIPTION
Fixes the import error caused while calling the TransformerLoss function in TransformerTTS.py