### PR TITLE
Fix inference for multi-string inputs

### DIFF
--- a/InferenceInterfaces/InferenceFastSpeech2.py
+++ b/InferenceInterfaces/InferenceFastSpeech2.py
@@ -182,10 +182,16 @@ class InferenceFastSpeech2(torch.nn.Module):
                                energy_variance_scale=energy_variance_scale).cpu()
                     wav = torch.cat((wav, silence), 0)
                 else:
+                    if durations is not None:
+                        durations = durations.to(self.device)
+                    if pitch is not None:
+                        pitch = pitch.to(self.device)
+                    if energy is not None:
+                        energy = energy.to(self.device)
                     wav = torch.cat((wav, self(text,
-                                               durations=durations.to(self.device),
-                                               pitch=pitch.to(self.device),
-                                               energy=energy.to(self.device),
+                                               durations=durations,
+                                               pitch=pitch,
+                                               energy=energy,
                                                duration_scaling_factor=duration_scaling_factor,
                                                pitch_variance_scale=pitch_variance_scale,
                                                energy_variance_scale=energy_variance_scale).cpu()), 0)


### PR DESCRIPTION
It was failing if I modified the example `run_text_to_file_reader` to take a list of strings instead of a single string.
This fixes it, seemed like the obvious thing to do.
(previously fails on `durations.to` because durations is `None`)