### PR TITLE
centralize storage configuration

### DIFF
--- a/InferenceInterfaces/ControllableInterface.py
+++ b/InferenceInterfaces/ControllableInterface.py
@@ -4,6 +4,7 @@ import torch
 
 from InferenceInterfaces.Controllability.GAN import GanWrapper
 from InferenceInterfaces.FastSpeech2Interface import InferenceFastSpeech2
+from Utility.storage_config import MODELS_DIR
 
 
 class ControllableInterface:
@@ -16,7 +17,7 @@ class ControllableInterface:
             os.environ["CUDA_VISIBLE_DEVICES"] = f"{gpu_id}"
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.model = InferenceFastSpeech2(device=self.device, model_name="Meta")
-        self.wgan = GanWrapper('Models/Embedding/embedding_gan.pt', device=self.device)
+        self.wgan = GanWrapper(os.path.join(MODELS_DIR, "Embedding", "embedding_gan.pt"), device=self.device)
         self.current_language = "English"
         self.current_accent = "English"
         self.language_id_lookup = {

--- a/InferenceInterfaces/FastSpeech2Interface.py
+++ b/InferenceInterfaces/FastSpeech2Interface.py
@@ -17,6 +17,7 @@ from Preprocessing.AudioPreprocessor import AudioPreprocessor
 from Preprocessing.TextFrontend import ArticulatoryCombinedTextFrontend
 from Preprocessing.TextFrontend import get_language_id
 from TrainingInterfaces.Spectrogram_to_Embedding.StyleEmbedding import StyleEmbedding
+from Utility.storage_config import MODELS_DIR
 
 
 class InferenceFastSpeech2(torch.nn.Module):
@@ -41,7 +42,7 @@ class InferenceFastSpeech2(torch.nn.Module):
         ################################
         #   load weights               #
         ################################
-        checkpoint = torch.load(os.path.join("Models", f"FastSpeech2_{model_name}", "best.pt"), map_location='cpu')
+        checkpoint = torch.load(os.path.join(MODELS_DIR, f"FastSpeech2_{model_name}", "best.pt"), map_location='cpu')
 
         ################################
         #   load phone to mel model    #
@@ -64,14 +65,14 @@ class InferenceFastSpeech2(torch.nn.Module):
         #################################
         self.style_embedding_function = StyleEmbedding()
         self.style_embedding_function.eval()
-        check_dict = torch.load("Models/Embedding/embedding_function.pt", map_location="cpu")
+        check_dict = torch.load(os.path.join(MODELS_DIR, "Embedding", "embedding_function.pt"), map_location="cpu")
         self.style_embedding_function.load_state_dict(check_dict["style_emb_func"])
         self.style_embedding_function.to(self.device)
 
         ################################
         #  load mel to wave model      #
         ################################
-        self.mel2wav = torch.jit.trace(HiFiGANGenerator(path_to_weights=os.path.join("Models", "Avocodo", "best.pt")),
+        self.mel2wav = torch.jit.trace(HiFiGANGenerator(path_to_weights=os.path.join(MODELS_DIR, "Avocodo", "best.pt")),
                                        torch.rand((80, 50))).to(
             torch.device(device))
 

--- a/InferenceInterfaces/UtteranceCloner.py
+++ b/InferenceInterfaces/UtteranceCloner.py
@@ -13,6 +13,7 @@ from TrainingInterfaces.Text_to_Spectrogram.AutoAligner.Aligner import Aligner
 from TrainingInterfaces.Text_to_Spectrogram.FastSpeech2.DurationCalculator import DurationCalculator
 from TrainingInterfaces.Text_to_Spectrogram.FastSpeech2.EnergyCalculator import EnergyCalculator
 from TrainingInterfaces.Text_to_Spectrogram.FastSpeech2.PitchCalculator import Parselmouth
+from Utility.storage_config import MODELS_DIR
 
 
 class UtteranceCloner:
@@ -22,7 +23,7 @@ class UtteranceCloner:
         self.ap = AudioPreprocessor(input_sr=16000, output_sr=16000, melspec_buckets=80, hop_length=256, n_fft=1024, cut_silence=False)
         self.tf = ArticulatoryCombinedTextFrontend(language="en")
         self.device = device
-        acoustic_checkpoint_path = os.path.join("Models", "Aligner", "aligner.pt")
+        acoustic_checkpoint_path = os.path.join(MODELS_DIR, "Aligner", "aligner.pt")
         self.aligner_weights = torch.load(acoustic_checkpoint_path, map_location='cpu')["asr_model"]
         torch.hub._validate_not_a_forked_repo = lambda a, b, c: True  # torch 1.9 has a bug in the hub loading, this is a workaround
         # careful: assumes 16kHz or 8kHz audio

--- a/Preprocessing/GSTExtractor.py
+++ b/Preprocessing/GSTExtractor.py
@@ -1,3 +1,5 @@
+import os
+
 import torch
 import torch.multiprocessing
 import torch.multiprocessing
@@ -5,11 +7,12 @@ from numpy import trim_zeros
 
 from Preprocessing.AudioPreprocessor import AudioPreprocessor
 from TrainingInterfaces.Spectrogram_to_Embedding.StyleEmbedding import StyleEmbedding
+from Utility.storage_config import MODELS_DIR
 
 
 class ProsodicConditionExtractor:
 
-    def __init__(self, sr, device=torch.device("cpu"), path_to_model="Models/Embedding/embedding_function.pt"):
+    def __init__(self, sr, device=torch.device("cpu"), path_to_model=os.path.join(MODELS_DIR, "Embedding", "embedding_function.pt"):
         self.ap = AudioPreprocessor(input_sr=sr, output_sr=16000, melspec_buckets=80, hop_length=256, n_fft=1024, cut_silence=False)
         self.embed = StyleEmbedding()
         check_dict = torch.load(path_to_model, map_location="cpu")

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ systems, you'll also need to tell the phonemizer library where to find your espe
 [this issue](https://github.com/bootphon/phonemizer/issues/44#issuecomment-1008449718). Since the project is still in
 active development, there are frequent updates, which can actually benefit your use significantly.
 
+#### Storage configuration
+
+If you don't want the pretrained and trained models as well as the data resulting from preprocessing your datasets to be stored in the default subfolders, you can first set corresponding directories globally by editing *Utility/storage_config.py* to suit your needs (the path can be relative to the repository root directory or absolute).
+
 #### Pretrained Models
 
 You don't need to use pretrained models, but it can speed things up tremendously. Run the ```run_model_downloader.py```

--- a/TrainingInterfaces/Spectrogram_to_Embedding/finetune_embeddings_to_tasks.py
+++ b/TrainingInterfaces/Spectrogram_to_Embedding/finetune_embeddings_to_tasks.py
@@ -15,6 +15,7 @@ from Preprocessing.AudioPreprocessor import AudioPreprocessor
 from TrainingInterfaces.Spectrogram_to_Embedding.StyleEmbedding import StyleEmbedding
 from Utility.diverse_losses import BarlowTwinsLoss
 from Utility.diverse_losses import TripletLoss
+from Utility.storage_config import MODELS_DIR
 
 
 class Dataset:
@@ -139,7 +140,7 @@ def finetune_model_emotion(gpu_id, resume_checkpoint, resume, finetune, model_di
 
     emo_data.add_dataset(label_to_filelist)
     finetuned_model = finetune_model(emo_data, device=device)
-    torch.save({"style_emb_func": finetuned_model.state_dict()}, "Models/Embedding/emotion_embedding_function.pt")
+    torch.save({"style_emb_func": finetuned_model.state_dict()}, os.path.join(MODELS_DIR, "Embedding", "emotion_embedding_function.pt"))
 
 
 def finetune_model_speaker(gpu_id, resume_checkpoint, resume, finetune, model_dir):
@@ -295,10 +296,10 @@ def finetune_model_speaker(gpu_id, resume_checkpoint, resume, finetune, model_di
 
     speaker_data.add_dataset(label_to_filelist)
     finetuned_model = finetune_model(speaker_data, device=device)
-    torch.save({"style_emb_func": finetuned_model.state_dict()}, "Models/Embedding/speaker_embedding_function.pt")
+    torch.save({"style_emb_func": finetuned_model.state_dict()}, os.path.join(MODELS_DIR, "Embedding", "speaker_embedding_function.pt"))
 
 
-def finetune_model(dataset, device, path_to_embed="Models/Embedding/embedding_function.pt"):
+def finetune_model(dataset, device, path_to_embed=os.path.join(MODELS_DIR, "Embedding", "embedding_function.pt")):
     # initialize losses
     contrastive_loss = TripletLoss(margin=1.0)
     non_contrastive_loss = BarlowTwinsLoss().to(device)

--- a/TrainingInterfaces/Text_to_Spectrogram/AutoAligner/AlignerDataset.py
+++ b/TrainingInterfaces/Text_to_Spectrogram/AutoAligner/AlignerDataset.py
@@ -14,6 +14,7 @@ from tqdm import tqdm
 from Preprocessing.AudioPreprocessor import AudioPreprocessor
 from Preprocessing.TextFrontend import ArticulatoryCombinedTextFrontend
 from Preprocessing.articulatory_features import get_feature_to_index_lookup
+from Utility.storage_config import MODELS_DIR
 
 
 class AlignerDataset(Dataset):
@@ -93,7 +94,10 @@ class AlignerDataset(Dataset):
             self.speaker_embeddings = list()
             speaker_embedding_func_ecapa = EncoderClassifier.from_hparams(source="speechbrain/spkrec-ecapa-voxceleb",
                                                                           run_opts={"device": str(device)},
-                                                                          savedir="Models/SpeakerEmbedding/speechbrain_speaker_embedding_ecapa")
+                                                                          savedir=os.path.join(
+                                                                            MODELS_DIR, 
+                                                                            "SpeakerEmbedding", 
+                                                                            "speechbrain_speaker_embedding_ecapa"))
             with torch.no_grad():
                 for wave in tqdm(norm_waves):
                     self.speaker_embeddings.append(speaker_embedding_func_ecapa.encode_batch(wavs=wave.to(device).unsqueeze(0)).squeeze().cpu())

--- a/TrainingInterfaces/Text_to_Spectrogram/AutoAligner/AlignerDatasetBuilder.py
+++ b/TrainingInterfaces/Text_to_Spectrogram/AutoAligner/AlignerDatasetBuilder.py
@@ -17,6 +17,7 @@ from tqdm import tqdm
 
 from Preprocessing.AudioPreprocessor import AudioPreprocessor
 from Preprocessing.TextFrontend import ArticulatoryCombinedTextFrontend
+from Utility.storage_config import MODELS_DIR
 
 
 class AlignerDatasetBuilder(Dataset):
@@ -52,7 +53,10 @@ class AlignerDatasetBuilder(Dataset):
         self.device = device
         self.speaker_embedding_func_ecapa = EncoderClassifier.from_hparams(source="speechbrain/spkrec-ecapa-voxceleb",
                                                                            run_opts={"device": str(device)},
-                                                                           savedir="Models/SpeakerEmbedding/speechbrain_speaker_embedding_ecapa")
+                                                                           savedir=os.path.join(
+                                                                            MODELS_DIR, 
+                                                                            "SpeakerEmbedding", 
+                                                                            "speechbrain_speaker_embedding_ecapa"))
 
     def build_cache(self,
                     transcript_dict,

--- a/TrainingInterfaces/Text_to_Spectrogram/FastSpeech2/fastspeech2_train_loop.py
+++ b/TrainingInterfaces/Text_to_Spectrogram/FastSpeech2/fastspeech2_train_loop.py
@@ -20,6 +20,7 @@ from Utility.WarmupScheduler import WarmupScheduler
 from Utility.utils import cumsum_durations
 from Utility.utils import delete_old_checkpoints
 from Utility.utils import get_most_recent_checkpoint
+from Utility.storage_config import MODELS_DIR
 
 
 @torch.no_grad()
@@ -118,7 +119,7 @@ def train_loop(net,
                lr=0.0001,
                warmup_steps=4000,
                path_to_checkpoint=None,
-               path_to_embed_model="Models/Embedding/embedding_function.pt",
+               path_to_embed_model=os.path.join(MODELS_DIR, "Embedding", "embedding_function.pt"),
                fine_tune=False,
                resume=False,
                phase_1_steps=100000,

--- a/TrainingInterfaces/Text_to_Spectrogram/FastSpeech2/meta_train_loop.py
+++ b/TrainingInterfaces/Text_to_Spectrogram/FastSpeech2/meta_train_loop.py
@@ -1,3 +1,5 @@
+import os
+
 import librosa.display as lbd
 import matplotlib.pyplot as plt
 import torch
@@ -14,6 +16,7 @@ from Preprocessing.TextFrontend import get_language_id
 from TrainingInterfaces.Spectrogram_to_Embedding.StyleEmbedding import StyleEmbedding
 from Utility.WarmupScheduler import WarmupScheduler
 from Utility.path_to_transcript_dicts import *
+from Utility.storage_config import MODELS_DIR
 from Utility.utils import cumsum_durations
 from Utility.utils import delete_old_checkpoints
 from Utility.utils import get_most_recent_checkpoint
@@ -121,7 +124,7 @@ def train_loop(net,
                steps_per_checkpoint,
                lr,
                path_to_checkpoint,
-               path_to_embed_model="Models/Embedding/embedding_function.pt",
+               path_to_embed_model=os.path.join(MODELS_DIR, "Embedding", "embedding_function.pt"),
                resume=False,
                warmup_steps=4000,
                use_wandb=False):

--- a/TrainingInterfaces/TrainingPipelines/FastSpeech2_Controllable.py
+++ b/TrainingInterfaces/TrainingPipelines/FastSpeech2_Controllable.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 import torch
@@ -8,6 +9,7 @@ from TrainingInterfaces.Text_to_Spectrogram.FastSpeech2.FastSpeech2 import FastS
 from TrainingInterfaces.Text_to_Spectrogram.FastSpeech2.fastspeech2_train_loop import train_loop
 from Utility.corpus_preparation import prepare_fastspeech_corpus
 from Utility.path_to_transcript_dicts import *
+from Utility.storage_config import MODELS_DIR, PREPROCESSING_DIR
 
 
 def run(gpu_id, resume_checkpoint, finetune, model_dir, resume, use_wandb, wandb_resume_id):
@@ -29,34 +31,34 @@ def run(gpu_id, resume_checkpoint, finetune, model_dir, resume, use_wandb, wandb
     if model_dir is not None:
         save_dir = model_dir
     else:
-        save_dir = os.path.join("Models", "FastSpeech2_Controllable")
+        save_dir = os.path.join(MODELS_DIR, "FastSpeech2_Controllable")
     os.makedirs(save_dir, exist_ok=True)
 
     datasets = list()
     datasets.append(prepare_fastspeech_corpus(transcript_dict={},
-                                              corpus_dir=os.path.join("Corpora", "Nancy"),
+                                              corpus_dir=os.path.join(PREPROCESSING_DIR, "Nancy"),
                                               lang="en"))
 
     datasets.append(prepare_fastspeech_corpus(transcript_dict={},
-                                              corpus_dir=os.path.join("Corpora", "ravdess"),
+                                              corpus_dir=os.path.join(PREPROCESSING_DIR, "ravdess"),
                                               lang="en",
                                               ctc_selection=False))
 
     datasets.append(prepare_fastspeech_corpus(transcript_dict={},
-                                              corpus_dir=os.path.join("Corpora", "esds"),
+                                              corpus_dir=os.path.join(PREPROCESSING_DIR, "esds"),
                                               lang="en",
                                               ctc_selection=False))
 
     datasets.append(prepare_fastspeech_corpus(transcript_dict={},
-                                              corpus_dir=os.path.join("Corpora", "libri_all_clean"),
+                                              corpus_dir=os.path.join(PREPROCESSING_DIR, "libri_all_clean"),
                                               lang="en"))
 
     datasets.append(prepare_fastspeech_corpus(transcript_dict={},
-                                              corpus_dir=os.path.join("Corpora", "vctk"),
+                                              corpus_dir=os.path.join(PREPROCESSING_DIR, "vctk"),
                                               lang="en"))
 
     datasets.append(prepare_fastspeech_corpus(transcript_dict={},
-                                              corpus_dir=os.path.join("Corpora", "LJSpeech"),
+                                              corpus_dir=os.path.join(PREPROCESSING_DIR, "LJSpeech"),
                                               lang="en"))
     train_set = ConcatDataset(datasets)
 

--- a/TrainingInterfaces/TrainingPipelines/FastSpeech2_Embedding.py
+++ b/TrainingInterfaces/TrainingPipelines/FastSpeech2_Embedding.py
@@ -2,6 +2,7 @@
 This is the setup with which the embedding model is trained. After the embedding model has been trained, it is only used in a frozen state.
 """
 
+import os
 import time
 
 import torch
@@ -12,6 +13,7 @@ from TrainingInterfaces.Spectrogram_to_Embedding.embedding_function_train_loop i
 from TrainingInterfaces.Text_to_Spectrogram.FastSpeech2.FastSpeech2 import FastSpeech2
 from Utility.corpus_preparation import prepare_fastspeech_corpus
 from Utility.path_to_transcript_dicts import *
+from Utility.storage_config import MODELS_DIR, PREPROCESSING_DIR
 
 
 def run(gpu_id, resume_checkpoint, finetune, model_dir, resume, use_wandb, wandb_resume_id):
@@ -33,30 +35,30 @@ def run(gpu_id, resume_checkpoint, finetune, model_dir, resume, use_wandb, wandb
     if model_dir is not None:
         save_dir = model_dir
     else:
-        save_dir = os.path.join("Models", "FastSpeech2_Embedding")
+        save_dir = os.path.join(MODELS_DIR, "FastSpeech2_Embedding")
     os.makedirs(save_dir, exist_ok=True)
 
     datasets = list()
     datasets.append(prepare_fastspeech_corpus(transcript_dict={},
-                                              corpus_dir=os.path.join("Corpora", "ravdess"),
+                                              corpus_dir=os.path.join(PREPROCESSING_DIR, "ravdess"),
                                               lang="en",
                                               ctc_selection=False))
 
     datasets.append(prepare_fastspeech_corpus(transcript_dict={},
-                                              corpus_dir=os.path.join("Corpora", "esds"),
+                                              corpus_dir=os.path.join(PREPROCESSING_DIR, "esds"),
                                               lang="en",
                                               ctc_selection=False))
 
     datasets.append(prepare_fastspeech_corpus(transcript_dict={},
-                                              corpus_dir=os.path.join("Corpora", "libri_all_clean"),
+                                              corpus_dir=os.path.join(PREPROCESSING_DIR, "libri_all_clean"),
                                               lang="en"))
 
     datasets.append(prepare_fastspeech_corpus(transcript_dict={},
-                                              corpus_dir=os.path.join("Corpora", "Nancy"),
+                                              corpus_dir=os.path.join(PREPROCESSING_DIR, "Nancy"),
                                               lang="en"))
 
     datasets.append(prepare_fastspeech_corpus(transcript_dict={},
-                                              corpus_dir=os.path.join("Corpora", "LJSpeech"),
+                                              corpus_dir=os.path.join(PREPROCESSING_DIR, "LJSpeech"),
                                               lang="en"))
 
     # for the next iteration, we should add an augmented noisy version of e.g. Nancy,

--- a/TrainingInterfaces/TrainingPipelines/FastSpeech2_IntegrationTest.py
+++ b/TrainingInterfaces/TrainingPipelines/FastSpeech2_IntegrationTest.py
@@ -2,6 +2,7 @@
 This is basically an integration test
 """
 
+import os
 import time
 
 import torch
@@ -12,6 +13,7 @@ from TrainingInterfaces.Text_to_Spectrogram.FastSpeech2.FastSpeech2 import FastS
 from TrainingInterfaces.Text_to_Spectrogram.FastSpeech2.fastspeech2_train_loop import train_loop as tts_train_loop
 from Utility.corpus_preparation import prepare_fastspeech_corpus
 from Utility.path_to_transcript_dicts import *
+from Utility.storage_config import MODELS_DIR, PREPROCESSING_DIR
 
 
 def run(gpu_id, resume_checkpoint, finetune, model_dir, resume, use_wandb, wandb_resume_id):
@@ -33,11 +35,11 @@ def run(gpu_id, resume_checkpoint, finetune, model_dir, resume, use_wandb, wandb
     if model_dir is not None:
         save_dir = model_dir
     else:
-        save_dir = os.path.join("Models", "FastSpeech2_IntegrationTest")
+        save_dir = os.path.join(MODELS_DIR, "FastSpeech2_IntegrationTest")
     os.makedirs(save_dir, exist_ok=True)
 
     train_set = prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_integration_test(),
-                                          corpus_dir=os.path.join("Corpora", "IntegrationTest"),
+                                          corpus_dir=os.path.join(PREPROCESSING_DIR, "IntegrationTest"),
                                           lang="en",
                                           save_imgs=True)
 

--- a/TrainingInterfaces/TrainingPipelines/FastSpeech2_MetaCheckpoint.py
+++ b/TrainingInterfaces/TrainingPipelines/FastSpeech2_MetaCheckpoint.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 import torch
@@ -12,6 +13,7 @@ from TrainingInterfaces.Text_to_Spectrogram.FastSpeech2.FastSpeech2 import FastS
 from TrainingInterfaces.Text_to_Spectrogram.FastSpeech2.meta_train_loop import train_loop
 from Utility.corpus_preparation import prepare_fastspeech_corpus
 from Utility.path_to_transcript_dicts import *
+from Utility.storage_config import MODELS_DIR, PREPROCESSING_DIR
 
 
 def run(gpu_id, resume_checkpoint, finetune, model_dir, resume, use_wandb, wandb_resume_id, remove_faulty_samples=False, generate_all_aligner_caches=False):
@@ -29,7 +31,7 @@ def run(gpu_id, resume_checkpoint, finetune, model_dir, resume, use_wandb, wandb
 
     datasets = list()
 
-    base_dir = os.path.join("Models", "FastSpeech2_Meta")
+    base_dir = os.path.join(MODELS_DIR, "FastSpeech2_Meta")
     if model_dir is not None:
         meta_save_dir = model_dir
     else:
@@ -57,124 +59,124 @@ def run(gpu_id, resume_checkpoint, finetune, model_dir, resume, use_wandb, wandb
     vietnamese_datasets = list()
 
     english_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_nancy(),
-                                                      corpus_dir=os.path.join("Corpora", "Nancy"),
+                                                      corpus_dir=os.path.join(PREPROCESSING_DIR, "Nancy"),
                                                       lang="en"))
 
     english_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_ljspeech(),
-                                                      corpus_dir=os.path.join("Corpora", "LJSpeech"),
+                                                      corpus_dir=os.path.join(PREPROCESSING_DIR, "LJSpeech"),
                                                       lang="en"))
 
     english_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_libritts_all_clean(),
-                                                      corpus_dir=os.path.join("Corpora", "libri_all_clean"),
+                                                      corpus_dir=os.path.join(PREPROCESSING_DIR, "libri_all_clean"),
                                                       lang="en"))
 
     english_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_vctk(),
-                                                      corpus_dir=os.path.join("Corpora", "vctk"),
+                                                      corpus_dir=os.path.join(PREPROCESSING_DIR, "vctk"),
                                                       lang="en"))
 
     english_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_nvidia_hifitts(),
-                                                      corpus_dir=os.path.join("Corpora", "hifi"),
+                                                      corpus_dir=os.path.join(PREPROCESSING_DIR, "hifi"),
                                                       lang="en"))
 
     english_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_RAVDESS(),
-                                                      corpus_dir=os.path.join("Corpora", "ravdess"),
+                                                      corpus_dir=os.path.join(PREPROCESSING_DIR, "ravdess"),
                                                       lang="en",
                                                       ctc_selection=False))
 
     english_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_ESDS(),
-                                                      corpus_dir=os.path.join("Corpora", "esds"),
+                                                      corpus_dir=os.path.join(PREPROCESSING_DIR, "esds"),
                                                       lang="en"))
 
     german_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_karlsson(),
-                                                     corpus_dir=os.path.join("Corpora", "Karlsson"),
+                                                     corpus_dir=os.path.join(PREPROCESSING_DIR, "Karlsson"),
                                                      lang="de"))
 
     german_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_eva(),
-                                                     corpus_dir=os.path.join("Corpora", "Eva"),
+                                                     corpus_dir=os.path.join(PREPROCESSING_DIR, "Eva"),
                                                      lang="de"))
 
     german_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_hokus(),
-                                                     corpus_dir=os.path.join("Corpora", "Hokus"),
+                                                     corpus_dir=os.path.join(PREPROCESSING_DIR, "Hokus"),
                                                      lang="de"))
 
     german_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_bernd(),
-                                                     corpus_dir=os.path.join("Corpora", "Bernd"),
+                                                     corpus_dir=os.path.join(PREPROCESSING_DIR, "Bernd"),
                                                      lang="de"))
 
     german_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_hui_others(),
-                                                     corpus_dir=os.path.join("Corpora", "hui_others"),
+                                                     corpus_dir=os.path.join(PREPROCESSING_DIR, "hui_others"),
                                                      lang="de"))
 
     german_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_thorsten(),
-                                                     corpus_dir=os.path.join("Corpora", "Thorsten"),
+                                                     corpus_dir=os.path.join(PREPROCESSING_DIR, "Thorsten"),
                                                      lang="de"))
 
     greek_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_css10el(),
-                                                    corpus_dir=os.path.join("Corpora", "meta_Greek"),
+                                                    corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_Greek"),
                                                     lang="el"))
 
     spanish_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_spanish_blizzard_train(),
-                                                      corpus_dir=os.path.join("Corpora", "spanish_blizzard"),
+                                                      corpus_dir=os.path.join(PREPROCESSING_DIR, "spanish_blizzard"),
                                                       lang="es"))
 
     spanish_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_css10es(),
-                                                      corpus_dir=os.path.join("Corpora", "meta_Spanish"),
+                                                      corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_Spanish"),
                                                       lang="es"))
 
     spanish_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_mls_spanish(),
-                                                      corpus_dir=os.path.join("Corpora", "mls_spanish"),
+                                                      corpus_dir=os.path.join(PREPROCESSING_DIR, "mls_spanish"),
                                                       lang="es"))
 
     finnish_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_css10fi(),
-                                                      corpus_dir=os.path.join("Corpora", "meta_Finnish"),
+                                                      corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_Finnish"),
                                                       lang="fi"))
 
     russian_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_css10ru(),
-                                                      corpus_dir=os.path.join("Corpora", "meta_Russian"),
+                                                      corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_Russian"),
                                                       lang="ru"))
 
     hungarian_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_css10hu(),
-                                                        corpus_dir=os.path.join("Corpora", "meta_Hungarian"),
+                                                        corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_Hungarian"),
                                                         lang="hu"))
 
     dutch_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_css10nl(),
-                                                    corpus_dir=os.path.join("Corpora", "meta_Dutch"),
+                                                    corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_Dutch"),
                                                     lang="nl"))
 
     dutch_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_mls_dutch(),
-                                                    corpus_dir=os.path.join("Corpora", "mls_dutch"),
+                                                    corpus_dir=os.path.join(PREPROCESSING_DIR, "mls_dutch"),
                                                     lang="nl"))
 
     french_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_css10fr(),
-                                                     corpus_dir=os.path.join("Corpora", "meta_French"),
+                                                     corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_French"),
                                                      lang="fr"))
 
     french_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_mls_french(),
-                                                     corpus_dir=os.path.join("Corpora", "mls_french"),
+                                                     corpus_dir=os.path.join(PREPROCESSING_DIR, "mls_french"),
                                                      lang="fr"))
 
     portuguese_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_mls_portuguese(),
-                                                         corpus_dir=os.path.join("Corpora", "mls_porto"),
+                                                         corpus_dir=os.path.join(PREPROCESSING_DIR, "mls_porto"),
                                                          lang="pt"))
 
     polish_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_mls_polish(),
-                                                     corpus_dir=os.path.join("Corpora", "mls_polish"),
+                                                     corpus_dir=os.path.join(PREPROCESSING_DIR, "mls_polish"),
                                                      lang="pl"))
 
     italian_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_mls_italian(),
-                                                      corpus_dir=os.path.join("Corpora", "mls_italian"),
+                                                      corpus_dir=os.path.join(PREPROCESSING_DIR, "mls_italian"),
                                                       lang="it"))
 
     chinese_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_css10cmn(),
-                                                      corpus_dir=os.path.join("Corpora", "css10_chinese"),
+                                                      corpus_dir=os.path.join(PREPROCESSING_DIR, "css10_chinese"),
                                                       lang="cmn"))
 
     chinese_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_aishell3(),
-                                                      corpus_dir=os.path.join("Corpora", "aishell3"),
+                                                      corpus_dir=os.path.join(PREPROCESSING_DIR, "aishell3"),
                                                       lang="cmn"))
 
     vietnamese_datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_vietTTS(),
-                                                         corpus_dir=os.path.join("Corpora", "vietTTS"),
+                                                         corpus_dir=os.path.join(PREPROCESSING_DIR, "vietTTS"),
                                                          lang="vi"))
 
     datasets.append(ConcatDataset(english_datasets))
@@ -229,7 +231,7 @@ def run(gpu_id, resume_checkpoint, finetune, model_dir, resume, use_wandb, wandb
                steps_per_checkpoint=1000,
                lr=0.001,
                path_to_checkpoint=resume_checkpoint,
-               path_to_embed_model="Models/Embedding/embedding_function.pt",
+               path_to_embed_model=os.path.join(MODELS_DIR, "Embedding", "embedding_function.pt"),
                resume=resume,
                use_wandb=use_wandb)
     if use_wandb:
@@ -241,7 +243,7 @@ def find_and_remove_faulty_samples(net,
                                    datasets,
                                    device,
                                    path_to_checkpoint,
-                                   path_to_embedding_checkpoint="Models/Embedding/embedding_function.pt"):
+                                   path_to_embedding_checkpoint=os.path.join(MODELS_DIR, "Embedding", "embedding_function.pt")):
     net = net.to(device)
     torch.multiprocessing.set_sharing_strategy('file_system')
     check_dict = torch.load(os.path.join(path_to_checkpoint), map_location=device)
@@ -273,121 +275,121 @@ def find_and_remove_faulty_samples(net,
 def build_all_aligner_dataset_caches(device):
     factory = AlignerDatasetBuilder(device=device)
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_nancy(),
-                        corpus_dir=os.path.join("Corpora", "Nancy"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "Nancy"),
                         lang="en")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_ljspeech(),
-                        corpus_dir=os.path.join("Corpora", "LJSpeech"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "LJSpeech"),
                         lang="en")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_libritts_all_clean(),
-                        corpus_dir=os.path.join("Corpora", "libri_all_clean"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "libri_all_clean"),
                         lang="en")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_vctk(),
-                        corpus_dir=os.path.join("Corpora", "vctk"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "vctk"),
                         lang="en")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_nvidia_hifitts(),
-                        corpus_dir=os.path.join("Corpora", "hifi"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "hifi"),
                         lang="en")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_RAVDESS(),
-                        corpus_dir=os.path.join("Corpora", "ravdess"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "ravdess"),
                         lang="en")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_ESDS(),
-                        corpus_dir=os.path.join("Corpora", "esds"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "esds"),
                         lang="en")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_karlsson(),
-                        corpus_dir=os.path.join("Corpora", "Karlsson"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "Karlsson"),
                         lang="de")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_eva(),
-                        corpus_dir=os.path.join("Corpora", "Eva"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "Eva"),
                         lang="de")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_hokus(),
-                        corpus_dir=os.path.join("Corpora", "Hokus"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "Hokus"),
                         lang="de")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_bernd(),
-                        corpus_dir=os.path.join("Corpora", "Bernd"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "Bernd"),
                         lang="de")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_hui_others(),
-                        corpus_dir=os.path.join("Corpora", "hui_others"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "hui_others"),
                         lang="de")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_thorsten(),
-                        corpus_dir=os.path.join("Corpora", "Thorsten"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "Thorsten"),
                         lang="de")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_css10el(),
-                        corpus_dir=os.path.join("Corpora", "meta_Greek"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_Greek"),
                         lang="el")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_spanish_blizzard_train(),
-                        corpus_dir=os.path.join("Corpora", "spanish_blizzard"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "spanish_blizzard"),
                         lang="es")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_css10es(),
-                        corpus_dir=os.path.join("Corpora", "meta_Spanish"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_Spanish"),
                         lang="es")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_mls_spanish(),
-                        corpus_dir=os.path.join("Corpora", "mls_spanish"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "mls_spanish"),
                         lang="es")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_css10fi(),
-                        corpus_dir=os.path.join("Corpora", "meta_Finnish"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_Finnish"),
                         lang="fi")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_css10ru(),
-                        corpus_dir=os.path.join("Corpora", "meta_Russian"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_Russian"),
                         lang="ru")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_css10hu(),
-                        corpus_dir=os.path.join("Corpora", "meta_Hungarian"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_Hungarian"),
                         lang="hu")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_css10nl(),
-                        corpus_dir=os.path.join("Corpora", "meta_Dutch"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_Dutch"),
                         lang="nl")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_mls_dutch(),
-                        corpus_dir=os.path.join("Corpora", "mls_dutch"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "mls_dutch"),
                         lang="nl")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_css10fr(),
-                        corpus_dir=os.path.join("Corpora", "meta_French"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_French"),
                         lang="fr")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_mls_french(),
-                        corpus_dir=os.path.join("Corpora", "mls_french"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "mls_french"),
                         lang="fr")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_mls_portuguese(),
-                        corpus_dir=os.path.join("Corpora", "mls_porto"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "mls_porto"),
                         lang="pt")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_mls_polish(),
-                        corpus_dir=os.path.join("Corpora", "mls_polish"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "mls_polish"),
                         lang="pl")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_mls_italian(),
-                        corpus_dir=os.path.join("Corpora", "mls_italian"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "mls_italian"),
                         lang="it")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_css10cmn(),
-                        corpus_dir=os.path.join("Corpora", "css10_chinese"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "css10_chinese"),
                         lang="cmn")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_aishell3(),
-                        corpus_dir=os.path.join("Corpora", "aishell3"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "aishell3"),
                         lang="cmn")
 
     factory.build_cache(transcript_dict=build_path_to_transcript_dict_vietTTS(),
-                        corpus_dir=os.path.join("Corpora", "vietTTS"),
+                        corpus_dir=os.path.join(PREPROCESSING_DIR, "vietTTS"),
                         lang="vi")

--- a/TrainingInterfaces/TrainingPipelines/FastSpeech2_finetuning_example.py
+++ b/TrainingInterfaces/TrainingPipelines/FastSpeech2_finetuning_example.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 import torch
@@ -8,6 +9,7 @@ from TrainingInterfaces.Text_to_Spectrogram.FastSpeech2.FastSpeech2 import FastS
 from TrainingInterfaces.Text_to_Spectrogram.FastSpeech2.fastspeech2_train_loop import train_loop
 from Utility.corpus_preparation import prepare_fastspeech_corpus
 from Utility.path_to_transcript_dicts import *
+from Utility.storage_config import MODELS_DIR, PREPROCESSING_DIR 
 
 
 def run(gpu_id, resume_checkpoint, finetune, model_dir, resume, use_wandb, wandb_resume_id):
@@ -29,16 +31,16 @@ def run(gpu_id, resume_checkpoint, finetune, model_dir, resume, use_wandb, wandb
     if model_dir is not None:
         save_dir = model_dir
     else:
-        save_dir = os.path.join("Models", "FastSpeech2_German")  # KEEP THE 'FastSpeech2_' BUT CHANGE THE MODEL ID TO SOMETHING MEANINGFUL FOR YOUR DATA
+        save_dir = os.path.join(MODELS_DIR, "FastSpeech2_German")  # KEEP THE 'FastSpeech2_' BUT CHANGE THE MODEL ID TO SOMETHING MEANINGFUL FOR YOUR DATA
     os.makedirs(save_dir, exist_ok=True)
 
     datasets = list()
     datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_karlsson(),
-                                              corpus_dir=os.path.join("Corpora", "Karlsson"),
+                                              corpus_dir=os.path.join(PREPROCESSING_DIR, "Karlsson"),
                                               lang="de"))  # CHANGE THE TRANSCRIPT DICT, THE NAME OF THE CACHE DIRECTORY AND THE LANGUAGE TO YOUR NEEDS
 
     datasets.append(prepare_fastspeech_corpus(transcript_dict=build_path_to_transcript_dict_eva(),
-                                              corpus_dir=os.path.join("Corpora", "Eva"),
+                                              corpus_dir=os.path.join(PREPROCESSING_DIR, "Eva"),
                                               lang="de"))  # YOU CAN SIMPLY ADD MODE CORPORA AND DO THE SAME, BUT YOU DON'T HAVE TO, ONE IS ENOUGH
 
     train_set = ConcatDataset(datasets)
@@ -59,8 +61,8 @@ def run(gpu_id, resume_checkpoint, finetune, model_dir, resume, use_wandb, wandb
                epochs_per_save=1,
                warmup_steps=4000,
                # DOWNLOAD THIS INITIALIZATION MODELS FROM THE RELEASE PAGE OF THE GITHUB
-               path_to_checkpoint="Models/FastSpeech2_Meta/best.pt" if resume_checkpoint is None else resume_checkpoint,
-               path_to_embed_model="Models/Embedding/embedding_function.pt",
+               path_to_checkpoint=os.path.join(MODELS_DIR, "FastSpeech2_Meta", "best.pt") if resume_checkpoint is None else resume_checkpoint,
+               path_to_embed_model=os.path.join(MODELS_DIR, "Embedding", "embedding_function.pt"),
                fine_tune=True if resume_checkpoint is None else finetune,
                resume=resume,
                phase_1_steps=50000,

--- a/TrainingInterfaces/TrainingPipelines/HiFiGAN_Avocodo.py
+++ b/TrainingInterfaces/TrainingPipelines/HiFiGAN_Avocodo.py
@@ -1,4 +1,4 @@
-import os.path
+import os
 import time
 
 import torch
@@ -9,6 +9,7 @@ from TrainingInterfaces.Spectrogram_to_Wave.HiFiGAN.HiFiGANDataset import HiFiGA
 from TrainingInterfaces.Spectrogram_to_Wave.HiFiGAN.HiFiGAN_Discriminators import AvocodoHiFiGANJointDiscriminator
 from TrainingInterfaces.Spectrogram_to_Wave.HiFiGAN.hifigan_train_loop import train_loop
 from Utility.path_to_transcript_dicts import *
+from Utility.storage_config import MODELS_DIR
 
 
 def run(gpu_id, resume_checkpoint, finetune, resume, model_dir, use_wandb, wandb_resume_id):
@@ -29,7 +30,7 @@ def run(gpu_id, resume_checkpoint, finetune, resume, model_dir, use_wandb, wandb
     if model_dir is not None:
         model_save_dir = model_dir
     else:
-        model_save_dir = "Models/Avocodo_feat_match"
+        model_save_dir = os.path.join(MODELS_DIR, "Avocodo_feat_match")
     os.makedirs(model_save_dir, exist_ok=True)
 
     print("Preparing new data...")

--- a/TrainingInterfaces/TrainingPipelines/HiFiGAN_Avocodo_low_RAM.py
+++ b/TrainingInterfaces/TrainingPipelines/HiFiGAN_Avocodo_low_RAM.py
@@ -1,4 +1,4 @@
-import os.path
+import os
 import time
 
 import torch
@@ -9,6 +9,7 @@ from TrainingInterfaces.Spectrogram_to_Wave.HiFiGAN.HiFiGANDataset import HiFiGA
 from TrainingInterfaces.Spectrogram_to_Wave.HiFiGAN.HiFiGAN_Discriminators import AvocodoHiFiGANJointDiscriminator
 from TrainingInterfaces.Spectrogram_to_Wave.HiFiGAN.hifigan_train_loop import train_loop
 from Utility.path_to_transcript_dicts import *
+from Utility.storage_config import MODELS_DIR
 
 
 def run(gpu_id, resume_checkpoint, finetune, resume, model_dir, use_wandb, wandb_resume_id):
@@ -29,7 +30,7 @@ def run(gpu_id, resume_checkpoint, finetune, resume, model_dir, use_wandb, wandb
     if model_dir is not None:
         model_save_dir = model_dir
     else:
-        model_save_dir = "Models/Avocodo"
+        model_save_dir = os.path.join(MODELS_DIR, "Avocodo")
     os.makedirs(model_save_dir, exist_ok=True)
 
     full_lists_to_sample_sizes = {

--- a/TrainingInterfaces/TrainingPipelines/pretrain_aligner.py
+++ b/TrainingInterfaces/TrainingPipelines/pretrain_aligner.py
@@ -1,9 +1,12 @@
+import os
+
 import torch
 from torch.utils.data import ConcatDataset
 
 from TrainingInterfaces.Text_to_Spectrogram.AutoAligner.autoaligner_train_loop import train_loop as train_aligner
 from Utility.corpus_preparation import prepare_aligner_corpus
 from Utility.path_to_transcript_dicts import *
+from Utility.storage_config import MODELS_DIR, PREPROCESSING_DIR
 
 
 def run(gpu_id, resume_checkpoint, finetune, model_dir, resume, use_wandb, wandb_resume_id):
@@ -26,162 +29,162 @@ def run(gpu_id, resume_checkpoint, finetune, model_dir, resume, use_wandb, wandb
 
     datasets.append(prepare_aligner_corpus(transcript_dict=dict(random.sample(build_path_to_transcript_dict_mls_portuguese().items(), 20000)),
                                            # take only 20k samples from this, since the corpus is way too big,
-                                           corpus_dir=os.path.join("Corpora", "mls_porto"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "mls_porto"),
                                            lang="pt",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=dict(random.sample(build_path_to_transcript_dict_mls_polish().items(), 20000)),
                                            # take only 20k samples from this, since the corpus is way too big,
-                                           corpus_dir=os.path.join("Corpora", "mls_polish"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "mls_polish"),
                                            lang="pl",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=dict(random.sample(build_path_to_transcript_dict_mls_spanish().items(), 12000)),
                                            # take only 12k samples from this, since the corpus is way too big,
-                                           corpus_dir=os.path.join("Corpora", "mls_spanish"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "mls_spanish"),
                                            lang="es",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=dict(random.sample(build_path_to_transcript_dict_mls_french().items(), 12000)),
                                            # take only 12k samples from this, since the corpus is way too big
-                                           corpus_dir=os.path.join("Corpora", "mls_french"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "mls_french"),
                                            lang="fr",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=dict(random.sample(build_path_to_transcript_dict_mls_italian().items(), 20000)),
                                            # take only 20k samples from this, since the corpus is way too big,
-                                           corpus_dir=os.path.join("Corpora", "mls_italian"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "mls_italian"),
                                            lang="it",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=dict(random.sample(build_path_to_transcript_dict_mls_dutch().items(), 12000)),
                                            # take only 12k samples from this, since the corpus is way too big
-                                           corpus_dir=os.path.join("Corpora", "mls_dutch"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "mls_dutch"),
                                            lang="nl",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=build_path_to_transcript_dict_nancy(),
-                                           corpus_dir=os.path.join("Corpora", "Nancy"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "Nancy"),
                                            lang="en",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=build_path_to_transcript_dict_karlsson(),
-                                           corpus_dir=os.path.join("Corpora", "Karlsson"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "Karlsson"),
                                            lang="de",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=build_path_to_transcript_dict_css10el(),
-                                           corpus_dir=os.path.join("Corpora", "meta_Greek"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_Greek"),
                                            lang="el",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=build_path_to_transcript_dict_css10es(),
-                                           corpus_dir=os.path.join("Corpora", "meta_Spanish"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_Spanish"),
                                            lang="es",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=build_path_to_transcript_dict_css10fi(),
-                                           corpus_dir=os.path.join("Corpora", "meta_Finnish"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_Finnish"),
                                            lang="fi",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=build_path_to_transcript_dict_css10ru(),
-                                           corpus_dir=os.path.join("Corpora", "meta_Russian"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_Russian"),
                                            lang="ru",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=build_path_to_transcript_dict_css10hu(),
-                                           corpus_dir=os.path.join("Corpora", "meta_Hungarian"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_Hungarian"),
                                            lang="hu",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=build_path_to_transcript_dict_css10nl(),
-                                           corpus_dir=os.path.join("Corpora", "meta_Dutch"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_Dutch"),
                                            lang="nl",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=build_path_to_transcript_dict_css10fr(),
-                                           corpus_dir=os.path.join("Corpora", "meta_French"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "meta_French"),
                                            lang="fr",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=build_path_to_transcript_dict_ljspeech(),
-                                           corpus_dir=os.path.join("Corpora", "LJSpeech"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "LJSpeech"),
                                            lang="en",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=build_path_to_transcript_dict_libritts(),
-                                           corpus_dir=os.path.join("Corpora", "libri"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "libri"),
                                            lang="en",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=dict(random.sample(build_path_to_transcript_dict_vctk().items(), 20000)),
                                            # take only 20k samples from this, since the corpus is way too big,
-                                           corpus_dir=os.path.join("Corpora", "vctk"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "vctk"),
                                            lang="en",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=dict(random.sample(build_path_to_transcript_dict_nvidia_hifitts().items(), 20000)),
                                            # take only 20k samples from this, since the corpus is way too big,
-                                           corpus_dir=os.path.join("Corpora", "hifi"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "hifi"),
                                            lang="en",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=build_path_to_transcript_dict_spanish_blizzard_train(),
-                                           corpus_dir=os.path.join("Corpora", "spanish_blizzard"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "spanish_blizzard"),
                                            lang="es",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=build_path_to_transcript_dict_eva(),
-                                           corpus_dir=os.path.join("Corpora", "Eva"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "Eva"),
                                            lang="de",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=dict(random.sample(build_path_to_transcript_dict_hokus().items(), 10000)),
                                            # take only 10k samples from this
-                                           corpus_dir=os.path.join("Corpora", "Hokus"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "Hokus"),
                                            lang="de",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=dict(random.sample(build_path_to_transcript_dict_bernd().items(), 12000)),
                                            # take only 12k samples from this, since the corpus is way too big,
-                                           corpus_dir=os.path.join("Corpora", "Bernd"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "Bernd"),
                                            lang="de",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=build_path_to_transcript_dict_hui_others(),
-                                           corpus_dir=os.path.join("Corpora", "hui_others"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "hui_others"),
                                            lang="de",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=dict(random.sample(build_path_to_transcript_dict_thorsten().items(), 12000)),
                                            # take only 12k samples from this, since the corpus is not that high quality,
-                                           corpus_dir=os.path.join("Corpora", "Thorsten"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "Thorsten"),
                                            lang="de",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=build_path_to_transcript_dict_fluxsing(),
-                                           corpus_dir=os.path.join("Corpora", "flux_sing"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "flux_sing"),
                                            lang="en",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=build_path_to_transcript_dict_css10cmn(),
-                                           corpus_dir=os.path.join("Corpora", "css10_chinese"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "css10_chinese"),
                                            lang="cmn",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=build_path_to_transcript_dict_aishell3(),
-                                           corpus_dir=os.path.join("Corpora", "aishell3"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "aishell3"),
                                            lang="cmn",
                                            device=device))
 
     datasets.append(prepare_aligner_corpus(transcript_dict=build_path_to_transcript_dict_VIVOS_viet(),
-                                           corpus_dir=os.path.join("Corpora", "VIVOS_viet"),
+                                           corpus_dir=os.path.join(PREPROCESSING_DIR, "VIVOS_viet"),
                                            lang="vi",
                                            device=device))
 
     train_set = ConcatDataset(datasets)
-    save_dir = os.path.join("Models", "Aligner")
+    save_dir = os.path.join(MODELS_DIR, "Aligner")
     os.makedirs(save_dir, exist_ok=True)
     save_dir_aligner = save_dir + "/aligner"
     os.makedirs(save_dir_aligner, exist_ok=True)

--- a/Utility/Scorer.py
+++ b/Utility/Scorer.py
@@ -7,6 +7,7 @@ can help you find outliers in the audio part of text-audio pairs.
 """
 
 import math
+import os
 
 import torch
 from tqdm import tqdm
@@ -17,6 +18,7 @@ from TrainingInterfaces.Spectrogram_to_Embedding.StyleEmbedding import StyleEmbe
 from TrainingInterfaces.Text_to_Spectrogram.AutoAligner.Aligner import Aligner
 from TrainingInterfaces.Text_to_Spectrogram.FastSpeech2.FastSpeech2 import FastSpeech2
 from Utility.corpus_preparation import prepare_fastspeech_corpus
+from Utility.storage_config import MODELS_DIR
 
 
 class AlignmentScorer:
@@ -79,7 +81,7 @@ class TTSScorer:
     def __init__(self,
                  path_to_fastspeech_model,
                  device,
-                 path_to_embedding_checkpoint="Models/Embedding/embedding_function.pt"
+                 path_to_embedding_checkpoint=os.path.join(MODELS_DIR, "Embedding", "embedding_function.pt")
                  ):
         self.device = device
         self.path_to_score = dict()

--- a/Utility/corpus_preparation.py
+++ b/Utility/corpus_preparation.py
@@ -1,3 +1,5 @@
+import os
+
 import torch
 import torch.multiprocessing
 
@@ -5,6 +7,7 @@ from TrainingInterfaces.Text_to_Spectrogram.AutoAligner.AlignerDataset import Al
 from TrainingInterfaces.Text_to_Spectrogram.AutoAligner.autoaligner_train_loop import train_loop as train_aligner
 from TrainingInterfaces.Text_to_Spectrogram.FastSpeech2.FastSpeechDataset import FastSpeechDataset
 from Utility.path_to_transcript_dicts import *
+from Utility.storage_config import MODELS_DIR
 
 
 def prepare_aligner_corpus(transcript_dict, corpus_dir, lang, device):
@@ -31,16 +34,16 @@ def prepare_fastspeech_corpus(transcript_dict,
     Skips parts that have been done before.
     """
     if fine_tune_aligner:
-        aligner_dir = os.path.join(corpus_dir, "aligner")
+        aligner_dir = os.path.join(corpus_dir, "Aligner")
         if not os.path.exists(os.path.join(aligner_dir, "aligner.pt")):
             aligner_datapoints = AlignerDataset(transcript_dict, cache_dir=corpus_dir, lang=lang, phone_input=phone_input, device=torch.device("cuda"))
-            if os.path.exists("Models/Aligner/aligner.pt"):
+            if os.path.exists(os.path.join(MODELS_DIR, "Aligner", "aligner.pt")):
                 train_aligner(train_dataset=aligner_datapoints,
                               device=torch.device("cuda"),
                               save_directory=aligner_dir,
                               steps=(len(aligner_datapoints) * 5) // 32,
                               batch_size=32,
-                              path_to_checkpoint="Models/Aligner/aligner.pt",
+                              path_to_checkpoint=os.path.join(MODELS_DIR, "Aligner", "aligner.pt"),
                               fine_tune=True,
                               debug_img_path=aligner_dir,
                               resume=False,
@@ -57,7 +60,7 @@ def prepare_fastspeech_corpus(transcript_dict,
                               resume=False,
                               use_reconstruction=use_reconstruction)
     else:
-        aligner_dir = "Models/Aligner/"
+        aligner_dir = os.path.join(MODELS_DIR, "Aligner")
     return FastSpeechDataset(transcript_dict,
                              acoustic_checkpoint_path=os.path.join(aligner_dir, "aligner.pt"),
                              cache_dir=corpus_dir,

--- a/Utility/storage_config.py
+++ b/Utility/storage_config.py
@@ -1,0 +1,2 @@
+MODELS_DIR = "Models/"
+PREPROCESSING_DIR = "Corpora/"

--- a/run_interactive_demo.py
+++ b/run_interactive_demo.py
@@ -5,10 +5,11 @@ import warnings
 import torch
 
 from InferenceInterfaces.FastSpeech2Interface import InferenceFastSpeech2
+from Utility.storage_config import MODELS_DIR
 
 if __name__ == '__main__':
     warnings.filterwarnings("ignore", category=UserWarning)
-    available_models = os.listdir("Models")
+    available_models = os.listdir(MODELS_DIR)
     available_fastspeech_models = list()
     for model in available_models:
         if model.startswith("FastSpeech2_"):

--- a/run_model_downloader.py
+++ b/run_model_downloader.py
@@ -1,6 +1,7 @@
 import os
 import urllib.request
 
+from Utility.storage_config import MODELS_DIR
 
 def report(block_number, read_size, total_size):
     if block_number % 1000 == 0:
@@ -15,42 +16,42 @@ def report(block_number, read_size, total_size):
 def download_models():
     #############
     print("Downloading Aligner Model")
-    os.makedirs("Models/Aligner", exist_ok=True)
+    os.makedirs(os.path.join(MODELS_DIR, "Aligner"), exist_ok=True)
     filename, headers = urllib.request.urlretrieve(
         url="https://github.com/DigitalPhonetics/IMS-Toucan/releases/download/v2.3/aligner.pt",
-        filename=os.path.abspath("./Models/Aligner/aligner.pt"),
+        filename=os.path.abspath(os.path.join(MODELS_DIR, "Aligner", "aligner.pt")),
         reporthook=report)
 
     #############
     print("Downloading Multilingual FastSpeech 2 Model")
-    os.makedirs("Models/FastSpeech2_Meta", exist_ok=True)
+    os.makedirs(os.path.join(MODELS_DIR, "FastSpeech2_Meta"), exist_ok=True)
     filename, headers = urllib.request.urlretrieve(
         url="https://github.com/DigitalPhonetics/IMS-Toucan/releases/download/v2.3/FastSpeech2_Meta.pt",
-        filename=os.path.abspath("./Models/FastSpeech2_Meta/best.pt"),
+        filename=os.path.abspath(os.path.join(MODELS_DIR, "FastSpeech2_Meta", "best.pt")),
         reporthook=report)
 
     #############
     print("Downloading Vocoder Model")
-    os.makedirs("Models/Avocodo", exist_ok=True)
+    os.makedirs(os.path.join(MODELS_DIR, "Avocodo"), exist_ok=True)
     filename, headers = urllib.request.urlretrieve(
         url="https://github.com/DigitalPhonetics/IMS-Toucan/releases/download/v2.3/Avocodo.pt",
-        filename=os.path.abspath("./Models/Avocodo/best.pt"),
+        filename=os.path.abspath(os.path.join(MODELS_DIR, "Avocodo", "best.pt")),
         reporthook=report)
 
     #############
     print("Downloading Embedding Model")
-    os.makedirs("Models/Embedding", exist_ok=True)
+    os.makedirs(os.path.join(MODELS_DIR, "Embedding"), exist_ok=True)
     filename, headers = urllib.request.urlretrieve(
         url="https://github.com/DigitalPhonetics/IMS-Toucan/releases/download/v2.3/embedding_function.pt",
-        filename=os.path.abspath("./Models/Embedding/embedding_function.pt"),
+        filename=os.path.abspath(os.path.join(MODELS_DIR, "Embedding", "embedding_function.pt")),
         reporthook=report)
 
     #############
     print("Downloading Embedding GAN")
-    os.makedirs("Models/Embedding", exist_ok=True)
+    os.makedirs(os.path.join(MODELS_DIR, "Embedding"), exist_ok=True)
     filename, headers = urllib.request.urlretrieve(
         url="https://github.com/DigitalPhonetics/IMS-Toucan/releases/download/v2.3/embedding_gan.pt",
-        filename=os.path.abspath("./Models/Embedding/embedding_gan.pt"),
+        filename=os.path.abspath(os.path.join(MODELS_DIR, "Embedding", "embedding_gan.pt")),
         reporthook=report)
 
 

--- a/run_scorer.py
+++ b/run_scorer.py
@@ -3,18 +3,19 @@ Example use of the scorer utility to inspect data.
 
 (pre-)trained models and already cache files with extracted features are required.
 """
-
+import os
 from Utility.Scorer import AlignmentScorer
 from Utility.Scorer import TTSScorer
+from Utility.storage_config import MODELS_DIR, PREPROCESSING_DIR
 import torch
 
 exec_device = "cuda" if torch.cuda.is_available() else "cpu"
 
-alignment_scorer = AlignmentScorer(path_to_aligner_model="Models/Aligner/aligner.pt", device=exec_device)
-alignment_scorer.score(path_to_aligner_dataset="Corpora/IntegrationTest/aligner_train_cache.pt")
+alignment_scorer = AlignmentScorer(path_to_aligner_model=os.path.join(MODELS_DIR, "Aligner", "aligner.pt"), device=exec_device)
+alignment_scorer.score(path_to_aligner_dataset=os.path.join(PREPROCESSING_DIR, "IntegrationTest", "aligner_train_cache.pt"))
 alignment_scorer.show_samples_with_highest_loss(20)
 
-tts_scorer = TTSScorer(path_to_fastspeech_model="Models/FastSpeech2_IntegrationTest/best.pt", device=exec_device)
-tts_scorer.score(path_to_fastspeech_dataset="Corpora/IntegrationTest/", lang_id="en")
+tts_scorer = TTSScorer(path_to_fastspeech_model=os.path.join(MODELS_DIR, "FastSpeech2_IntegrationTest","best.pt"), device=exec_device)
+tts_scorer.score(path_to_fastspeech_dataset=os.path.join(PREPROCESSING_DIR, "IntegrationTest/"), lang_id="en")
 tts_scorer.show_samples_with_highest_loss(20)
 tts_scorer.remove_samples_with_highest_loss(20)

--- a/run_weight_averaging.py
+++ b/run_weight_averaging.py
@@ -8,6 +8,7 @@ import torch
 
 from TrainingInterfaces.Spectrogram_to_Wave.HiFiGAN.HiFiGAN import HiFiGANGenerator
 from TrainingInterfaces.Text_to_Spectrogram.FastSpeech2.FastSpeech2 import FastSpeech2
+from Utility.storage_config import MODELS_DIR
 
 
 def load_net_fast(path):
@@ -95,20 +96,20 @@ def save_model_for_use(model, name="", default_embed=None, dict_name="model"):
 
 
 def make_best_in_all(n=3):
-    for model_dir in os.listdir("Models"):
-        if os.path.isdir(f"Models/{model_dir}"):
+    for model_dir in os.listdir(MODELS_DIR):
+        if os.path.isdir(os.path.join(MODELS_DIR, model_dir)):
             if "HiFiGAN" in model_dir or "Avocodo" in model_dir:
-                checkpoint_paths = get_n_recent_checkpoints_paths(checkpoint_dir=f"Models/{model_dir}", n=n)
+                checkpoint_paths = get_n_recent_checkpoints_paths(checkpoint_dir=os.path.join(MODELS_DIR, model_dir), n=n)
                 if checkpoint_paths is None:
                     continue
                 averaged_model, _ = average_checkpoints(checkpoint_paths, load_func=load_net_hifigan)
-                save_model_for_use(model=averaged_model, name=f"Models/{model_dir}/best.pt", dict_name="generator")
+                save_model_for_use(model=averaged_model, name=os.path.join(MODELS_DIR, model_dir, "best.pt"), dict_name="generator")
             elif "FastSpeech2" in model_dir:
-                checkpoint_paths = get_n_recent_checkpoints_paths(checkpoint_dir=f"Models/{model_dir}", n=n)
+                checkpoint_paths = get_n_recent_checkpoints_paths(checkpoint_dir=os.path.join(MODELS_DIR, model_dir), n=n)
                 if checkpoint_paths is None:
                     continue
                 averaged_model, default_embed = average_checkpoints(checkpoint_paths, load_func=load_net_fast)
-                save_model_for_use(model=averaged_model, default_embed=default_embed, name=f"Models/{model_dir}/best.pt")
+                save_model_for_use(model=averaged_model, default_embed=default_embed, name=os.path.join(MODELS_DIR, model_dir, "best.pt"))
 
 
 def count_parameters(net):


### PR DESCRIPTION
Rationale: although some functions allow to pass a target directory as an argument, several parts of the code assume the models and preprocessing files are stored in subfolders of the code repository.

On the infrastructure I work with, I am required to store the data ("data" including not only the input datasets but the training and preprocessing results as well) in a place separated from the code. And so to be able to complete the (quite common I suppose) clone > download pretrained models > finetune FastSpeech2 > do test inference keeping the pretrained vocoder / aligner / embeddings workflow, I found my self having to change quite a number of files, adding more discrepancies from the upstream codebase than should be necessary. Possibly other people are in the same situation, hence this PR, which centralizes the "root" models and preprocessing directories in one file, which is referenced everywhere else in the code (the added benefit being to be able to move strorage places more easily, assuming the subfolders structure is the same).

The README has been updated, and the default values for the directories ensure same behavior as currently.

I hope you'll find it useful, and in any case I take the occasion to thank you very much for this repo and all the tremendous work behind it. :)

PS: the same could be done for input datasets and output audios directories, but it might be a bit less relevant as they are less "spread out" in different files, so I decided to stop there for now ;)